### PR TITLE
Fix http.request options to use search field in url.format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "sepia",
   "author": "Avik Das <avik.das@berkeley.edu>",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A VCR-like module that records HTTP interactions and plays them back for speed and reliability",
-  "keywords": ["http", "testing"],
+  "keywords": [
+    "http",
+    "testing"
+  ],
   "homepage": "https://github.com/linkedin/sepia",
   "bugs": "https://github.com/linkedin/sepia/issues",
   "repository": {

--- a/src/util.js
+++ b/src/util.js
@@ -327,12 +327,17 @@ function constructFilename(method, reqUrl, reqBody, reqHeaders) {
 // -- CONVENIENCE FUNCTIONS ----------------------------------------------------
 
 function urlFromHttpRequestOptions(options, protocol) {
+  var parsedPath = options.path.split('?');
+  var pathname = parsedPath.shift();
+  var search = parsedPath.join('?');
+
   var urlOptions = {
     protocol: protocol,
     hostname: options.hostname || options.host,
     auth: options.auth,
     port: options.port,
-    pathname: options.path
+    pathname: pathname,
+    search: search
   };
 
   return url.format(urlOptions);

--- a/test/util.js
+++ b/test/util.js
@@ -754,6 +754,16 @@ describe('utils.js', function() {
         'https'
       ).should.equal('https://my-hostname/my/path');
     });
+
+    it('parses ? properly"', function() {
+      urlFromHttpRequestOptions(
+        {
+          host: 'my-hostname',
+          path: '/my/path?foo=bar'
+        },
+        'https'
+      ).should.equal('https://my-hostname/my/path?foo=bar');
+    });
   });
 
   describe('#shouldForceLive', function() {


### PR DESCRIPTION
Broken in 0.8.26+.

`http.request(options)` does not support the 'search' or 'qs' fields, so the '?' is passed in the path. However, in `urlFromHttpRequestOptions` we use the path (with '?') for `pathname` in `url.format` which gets encoded in 0.8.26+ resulting in a fixture miss.
