### PR TITLE
Add setMaxListeners to response.connection

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -115,6 +115,7 @@ module.exports.configure = function(mode) {
         res.connection = {
           listeners: function() { return []; },
           once: function() {},
+          setMaxListeners: function() {},
           client: {
             authorized: true
           }


### PR DESCRIPTION
The commit below added a call to response.connection.setMaxListeners which need to be added to the fake response.connection otherwise it throws an error.

https://github.com/mikeal/request/commit/849c681846ce3b5492bd47261de391377a3ac19b
