### PR TITLE
add ability to fallback to global cassettes

### DIFF
--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -76,3 +76,7 @@ VCR_MODE=cache node examples/forceLive
 start_test 'test-specific fixture directories'
 rm -r fixtures/
 VCR_MODE=cache node examples/testName
+
+start_test 'test-specific fixture directories with fallback to global'
+rm -r fixtures/
+VCR_MODE=cache node examples/testNameWithFallback

--- a/examples/testNameWIthFallback.js
+++ b/examples/testNameWIthFallback.js
@@ -1,0 +1,193 @@
+// Copyright 2013 LinkedIn Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * -- TEST NAME WITH FALLBACK ----------------------------------------------------------------
+ *
+ * rm -r fixtures
+ * VCR_MODE=cache node examples/testNameWithFallback
+ *
+ * Exercise setting a test name in order to record fixtures into namespaced
+ * directories, while falling back to root level fixtures if the namespaced
+ * fixture does not exist.
+ *
+ * Additionally, setting the test name is done via an HTTP request, so that
+ * request must be cofigured to be live.
+ *
+ * Global Enpoints are created without a namespace "/globalEndpoint<...>"
+ * Regular Endpoints are created with a test namespace "/endpoint<...>"
+ *
+ * The order of the requests:
+ *
+ *  1.  Fire request to /globalEndpoint1 (global, cache miss)
+ *  2.  Fire request to /globalEndpoint2 (global, cache miss)
+ *
+ *  3.  Set the test name to "test1"     (has to be live).
+ *  4.  Fire request to /globalEndpoint1 (fallback,   cache hit)
+ *  5.  Fire request to /endpointA       (namespaced, cache miss)
+ *
+ *  6.  Set the test name to "test2" (has to be live).
+ *  7.  Fire request to /endpointB   (namespaced, cache miss)
+ *  8.  Fire request to /endpointB   (namespaced, cache hit)
+ *
+ *  9.  Fire request with test header "test1" to /endpointA       (namespace,  cache hit)
+ *  10. Fire request with test header "test1" to /globalEndpoint2 (fallback,   cache hit)
+ *  11. Fire request with test header "test1" to /endpointC       (namespaced, cache miss)
+ *
+ *  12. Fire request with test header "test2" to /endpointB       (namespaced, cache hit)
+ *  13. Fire request with test header "test2" to /globalEndpoint1 (fallback,   cache hit)
+ *  14. Fire request with test header "test2" to /endpointD       (namespaced, cache miss)
+ *
+ *  15. Fire request with test header "test3" to /globalEndpoint1 (fallback,   cache hit)
+ */
+
+var http = require('http');
+var request = require('request');
+var _ = require('lodash');
+var step = require('step');
+require('should');
+var common = require('./common');
+
+var sepia = require('..')
+  .withSepiaServer();
+
+// -- ECHO SERVER --------------------------------------------------------------
+
+// 1. Returns a random number.
+
+var httpServer = http.createServer(function(req, res) {
+  var headers = {
+    'Content-type': 'text/plain'
+  };
+
+  // One piece of functionality being tested is the use of the
+  // x-sepia-test-name header, which is not meant to be passed along to
+  // downstream services. For that reason, we pass that header back to the
+  // client so that it can test the absence of the header.
+  if (req.headers['x-sepia-test-name']) {
+    headers['x-sepia-test-name'] = req.headers['x-sepia-test-name'];
+  }
+
+  // simulate server latency
+  setTimeout(function() {
+    res.writeHead(200, headers);
+    res.end(Math.random().toString());
+  }, 500);
+}).listen(1337, '0.0.0.0');
+
+// -- HTTP REQUESTS ------------------------------------------------------------
+
+function setTestName(name, next) {
+  request({
+    method: 'post',
+    url: 'http://localhost:58080/testOptions/',
+    json: {
+      testName: name
+    }
+  }, function(err, data) {
+    console.log('SETTING TEST NAME TO', name);
+    console.log('  status :', data.statusCode);
+    console.log();
+
+    next();
+  });
+}
+
+function normalRequest(url, cacheHitExpected, next) {
+  var start = Date.now();
+
+  request({
+    url: 'http://localhost:1337/' + url
+  }, function(err, data, body) {
+    var time = Date.now() - start;
+
+    console.log('REQUEST TO: http://localhost:1337/' + url);
+    console.log('  status:', data.statusCode);
+    console.log('  body  :', body);
+    console.log('  time  :', time);
+
+    common.verify(function() {
+      common.shouldUseCache(cacheHitExpected, time);
+    });
+
+    console.log();
+
+    next();
+  });
+}
+
+function requestWithHeader(testName, url, cacheHitExpected, next) {
+  var start = Date.now();
+
+  request({
+    url: 'http://localhost:1337/' + url,
+    headers: {
+      'x-sepia-test-name': testName
+    }
+  }, function(err, data, body) {
+    var time = Date.now() - start;
+
+    console.log('REQUEST TO WITH TEST HEADER: http://localhost:1337/'+ url);
+    console.log('  status:', data.statusCode);
+    console.log('  body  :', body);
+    console.log('  time  :', time);
+
+    common.verify(function() {
+      common.shouldUseCache(cacheHitExpected, time);
+      data.headers.should.not.have.property('x-sepia-test-name');
+    });
+
+    console.log();
+
+    next();
+  });
+}
+
+// -- RUN EVERYTHING -----------------------------------------------------------
+
+// To change the test name, we have to be able to access the live server,
+// regardless of whether or not we're playing back fixtures.
+sepia.filter({
+  url: /:58080/,
+  forceLive: true
+});
+
+sepia.configure({
+  fallbackToGlobal: true
+});
+
+step(
+  function() { setTimeout(this, 100); }, // let the server start up
+  function() { normalRequest('globalEndpoint1', false, this); },
+  function() { normalRequest('globalEndpoint2', false, this);   },
+
+  function() { setTestName('test1', this); },
+  function() { normalRequest('globalEndpoint1', true, this);  },
+  function() { normalRequest('endpointA', false, this); },
+
+  function() { setTestName('test2', this); },
+  function() { normalRequest('endpointB', false, this); },
+
+  function() { requestWithHeader('test1', 'endpointA', true,  this); },
+  function() { requestWithHeader('test1', 'globalEndpoint2',  true,  this); },
+  function() { requestWithHeader('test1', 'endpointC', false, this); },
+
+  function() { requestWithHeader('test2', 'endpointB', true,  this); },
+  function() { requestWithHeader('test2', 'globalEndpoint1', true,  this); },
+  function() { requestWithHeader('test2', 'endpointD', false, this); },
+
+  function() { requestWithHeader('test3', 'globalEndpoint1', true,  this); },
+  _.bind(httpServer.close, httpServer),
+  _.bind(sepia.shutdown, sepia)
+);

--- a/src/cache.js
+++ b/src/cache.js
@@ -140,6 +140,11 @@ module.exports.configure = function(mode) {
       if (playbackHits && !forceLive && fs.existsSync(filename + '.headers')) {
         playback();
         return;
+      } else if(sepiaUtil.shouldFallbackToGlobal()) {
+        filename = sepiaUtil.constructFilename(options.method, reqUrl,
+          reqBody.toString(), options.headers);
+        playback();
+        return;
       }
 
       // If we are not recording, and the fixtures file does not exist, then

--- a/src/cache.js
+++ b/src/cache.js
@@ -137,14 +137,18 @@ module.exports.configure = function(mode) {
 
       // If the file exists and we allow playback (e.g. we are not in
       // record-only mode), then simply play back the call.
-      if (playbackHits && !forceLive && fs.existsSync(filename + '.headers')) {
-        playback();
-        return;
-      } else if(sepiaUtil.shouldFallbackToGlobal()) {
-        filename = sepiaUtil.constructFilename(options.method, reqUrl,
-          reqBody.toString(), options.headers);
-        playback();
-        return;
+      if (playbackHits && !forceLive) {
+        if(fs.existsSync(filename + '.headers')) {
+          playback();
+          return;
+        } else if(sepiaUtil.shouldFallbackToGlobal()) {
+          filename = sepiaUtil.constructFilename(options.method, reqUrl,
+            reqBody.toString(), options.headers);
+          if(fs.existsSync(filename + '.headers')) {
+            playback();
+            return;
+          }
+        }
       }
 
       // If we are not recording, and the fixtures file does not exist, then

--- a/src/util.js
+++ b/src/util.js
@@ -50,6 +50,9 @@ function reset() {
   // These test options are set via an HTTP request to the embedded HTTP server
   // provided by sepia. The options are reset each time any of them are set.
   globalOptions.testOptions = {};
+
+  // This allows scoped requests to fallback to global requests
+  globalOptions.fallbackToGlobal = false;
 }
 
 // automatically reset the state of the module when 'required'.
@@ -90,6 +93,10 @@ function configure(options) {
 
   if (options.debug != null) {
     globalOptions.debug = options.debug;
+  }
+
+  if (options.fallbackToGlobal != null) {
+    globalOptions.fallbackToGlobal = options.fallbackToGlobal;
   }
 }
 
@@ -423,6 +430,10 @@ function shouldForceLive(reqUrl) {
   });
 }
 
+function shouldFallbackToGlobal() {
+  return globalOptions.fallbackToGlobal;
+}
+
 function shouldFindMatchingFixtures() {
   return globalOptions.debug;
 }
@@ -437,6 +448,7 @@ module.exports.urlFromHttpRequestOptions = urlFromHttpRequestOptions;
 module.exports.shouldForceLive = shouldForceLive;
 module.exports.removeInternalHeaders = removeInternalHeaders;
 module.exports.findTheBestMatchingFixture = findTheBestMatchingFixture;
+module.exports.shouldFallbackToGlobal = shouldFallbackToGlobal;
 module.exports.shouldFindMatchingFixtures = shouldFindMatchingFixtures;
 
 module.exports.internal = {};

--- a/test/util.js
+++ b/test/util.js
@@ -853,6 +853,24 @@ describe('utils.js', function() {
     });
   });
 
+  describe('#shouldFallbackToGlobal', function() {
+    const shouldFallbackToGlobal = sepiaUtil.shouldFallbackToGlobal;
+
+    it('returns true when fallbackToGlobal is true', function() {
+      sepiaUtil.configure({
+        fallbackToGlobal: true
+      });
+      shouldFallbackToGlobal().should.equal(true);
+    });
+
+    it('returns false when fallbackToGlobal is false', function() {
+      sepiaUtil.configure({
+        fallbackToGlobal: false
+      });
+      shouldFallbackToGlobal().should.equal(false);
+    });
+  });
+
   describe('#findTheBestMatchingFixture', function() {
 
     beforeEach(function() {
@@ -961,4 +979,3 @@ describe('utils.js', function() {
 
   });
 });
-


### PR DESCRIPTION
like in ruby's VCR gem, sometimes you want the ability to specify a set to use, but still fallback to a global set if possible.

This PR adds that ability by specifying `fallbackToGlobal: true` in `sepia.configure({...})`
