### PR TITLE
Fixed EINVAL error with fs.utimesSync() due to incorrect Unix timestamp

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -31,6 +31,7 @@
   "laxbreak": false,
   "laxcomma": false,
   "loopfunc": false,
+  "maxlen": 80,
   "multistr": true,
   "newcap": false,
   "noarg": true,

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The full list of options are as follows:
 
 - `verbose`: outputs extra data whenever a fixture is accessed, along with the
   parts used to create the name of the fixture.
+- `touchHits`: disable timestamp update of fixture files on a cache hit.
 - `includeHeaderNames`, `headerWhitelist`, `includeCookieNames`,
   `cookieWhitelist`: detailed in a later section.
 - 'debug': Useful for debugging the requests when there is a cache miss. If

--- a/README.md
+++ b/README.md
@@ -394,10 +394,12 @@ data is retrieved from a file and sent back using a dummy response object.
 
 ## Contributors
 
+* [Avik Das](https://github.com/avik-das)
 * [Vlad Shlosberg](https://github.com/vshlos)
 * [Ethan Goldblum](https://github.com/egoldblum)
 * [Shao-Hua Kao](https://github.com/ethankao)
 * [Deepank Gupta](https://github.com/deepankgupta)
 * [Priyanka Salvi](https://github.com/salvipriyanka/)
 * [Ashima Atul](https://github.com/ashimaatul)
-
+* [Delwyn de Villiers](https://github.com/delwyn)
+* [Mark Seminatore](https://github.com/mseminatore)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sepia",
   "author": "Avik Das <avik.das@berkeley.edu>",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A VCR-like module that records HTTP interactions and plays them back for speed and reliability",
   "keywords": [
     "http",

--- a/src/util.js
+++ b/src/util.js
@@ -177,7 +177,7 @@ function touchOnHit(filename) {
   }
 
   filename = filename + '.headers';
-  var now = Infinity;	// per NodeJS this will correctly set timestamp to Date.now() / 1000
+  var now = Date.now() / 1000;
 
   if (fs.existsSync(filename)) {
     fs.utimesSync(filename, now, now);

--- a/src/util.js
+++ b/src/util.js
@@ -177,7 +177,7 @@ function touchOnHit(filename) {
   }
 
   filename = filename + '.headers';
-  var now = Date.now();
+  var now = Infinity;	// per NodeJS this will correctly set timestamp to Date.now() / 1000
 
   if (fs.existsSync(filename)) {
     fs.utimesSync(filename, now, now);

--- a/src/util.js
+++ b/src/util.js
@@ -177,7 +177,7 @@ function touchOnHit(filename) {
   }
 
   filename = filename + '.headers';
-  var now = Date.now();
+  var now = Date.now() / 1000;
 
   if (fs.existsSync(filename)) {
     fs.utimesSync(filename, now, now);

--- a/test/util.js
+++ b/test/util.js
@@ -273,7 +273,7 @@ describe('utils.js', function() {
     const touchOnHit = sepiaUtil.internal.touchOnHit;
 
     beforeEach(function() {
-      sinon.stub(Date, 'now').returns('now');
+      sinon.stub(Date, 'now').returns(10000);
       sinon.stub(fs, 'utimesSync'); // utimesSync becomes a noop
     });
 
@@ -288,7 +288,7 @@ describe('utils.js', function() {
       fs.existsSync.withArgs('my-filename.headers').returns(true);
 
       touchOnHit('my-filename');
-      fs.utimesSync.calledWithExactly('my-filename.headers', 'now', 'now')
+      fs.utimesSync.calledWithExactly('my-filename.headers', 10, 10)
         .should.equal(true);
     });
 


### PR DESCRIPTION
This should address issue #17 