### PR TITLE
Substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,16 @@ Examples of this functionality can be seen in `examples/headers.js`:
     rm -r fixtures # in case you had previously generated fixtures
     VCR_MODE=cache node examples/headers
 
+## Hiding Sensitive Data
+
+It is good practice to avoid checking sensitive data into source control.  Sepia
+can substituting specific text in headers and bodies with values you specify. The substitute function takes a substitution string as a first argument and a function which
+returns the actual value, presumably retrieved from the environment.  Your fixtures
+will contain the substitution string, and can be safely committed to source control.
+
+    var sepia = require('sepia');
+    sepia.substitute('<SUBSTITUTION1>', function() { return process.env.MY_API_SECRET; });
+
 ## Languages
 
 A downstream request may return different data based on the language requested
@@ -399,4 +409,3 @@ data is retrieved from a file and sent back using a dummy response object.
 * [Deepank Gupta](https://github.com/deepankgupta)
 * [Priyanka Salvi](https://github.com/salvipriyanka/)
 * [Ashima Atul](https://github.com/ashimaatul)
-

--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -76,3 +76,8 @@ VCR_MODE=cache node examples/forceLive
 start_test 'test-specific fixture directories'
 rm -r fixtures/
 VCR_MODE=cache node examples/testName
+
+start_test 'substitute secrets'
+rm -r fixtures/
+VCR_MODE=record   node examples/substitutions
+VCR_MODE=playback node examples/substitutions

--- a/examples/substitutions.js
+++ b/examples/substitutions.js
@@ -1,0 +1,98 @@
+// Copyright 2013 LinkedIn Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * -- CACHE --------------------------------------------------------------------
+ *
+ * rm -r fixtures
+ * VCR_MODE=cache node examples/cache
+ *
+ * Exercise the cache mode by making an HTTP request without any fixtures, then
+ * re-making that request. The request should take substantially less time the
+ * second time, since the fixture will be created by the first call.
+ */
+
+var http = require('http');
+var request = require('request');
+var step = require('step');
+var common = require('./common');
+var sepia = require('..');
+
+require('..');
+
+// -- ECHO SERVER --------------------------------------------------------------
+
+var httpServer = http.createServer(function(req, res) {
+  req.setEncoding('utf-8');
+  var body = '';
+  req.on('data', function(chunk) {
+    body += chunk;
+  });
+
+  req.on('end', function() {
+    req.headers.authorization.should.equal('CLIENT:TheActualSecret1');
+    body.should.equal('Hello from client => TheActualSecret2');
+
+    // simulate server latency
+    setTimeout(function() {
+      res.writeHead(200,  { 'authorization': 'SERVER:TheActualSecret3' });
+      res.end('Hello from server => TheActualSecret4');
+    }, 500);
+  });
+}).listen(1337, '0.0.0.0');
+
+// -- HTTP REQUESTS ------------------------------------------------------------
+
+function makeRequest(title, cacheHitExpected, next) {
+  var start = Date.now();
+
+  request({
+    method: 'post',
+    headers: { authorization: 'CLIENT:TheActualSecret1'},
+    url: 'http://localhost:1337/',
+    body: 'Hello from client => TheActualSecret2'
+  }, function(err, data, body) {
+    var time = Date.now() - start;
+
+    console.log(title);
+    console.log('  status:', data.statusCode);
+    console.log('  time  :', time);
+
+    common.verify(function() {
+      data.headers.authorization.should.equal('SERVER:TheActualSecret3');
+      body.should.equal('Hello from server => TheActualSecret4');
+      //common.shouldUseCache(cacheHitExpected, time);
+    });
+
+    console.log();
+
+    next();
+  });
+}
+
+// -- RUN EVERYTHING -----------------------------------------------------------
+
+step(
+  function() {
+    sepia.substitute('<OPAQUE_SECRET1>', function() { return 'TheActualSecret1'; });
+    sepia.substitute('<OPAQUE_SECRET2>', function() { return 'TheActualSecret2'; });
+    sepia.substitute('<OPAQUE_SECRET3>', function() { return 'TheActualSecret3'; });
+    sepia.substitute('<OPAQUE_SECRET4>', function() { return 'TheActualSecret4'; });
+
+    setTimeout(this, 100);
+  }, // let the server start up
+  function() { makeRequest('NO FIXTURES' , false, this); },
+  function() { makeRequest('YES FIXTURES', true , this); },
+  httpServer.close.bind(httpServer)
+);

--- a/examples/substitutions.js
+++ b/examples/substitutions.js
@@ -27,9 +27,7 @@ var http = require('http');
 var request = require('request');
 var step = require('step');
 var common = require('./common');
-var sepiaUtil = require('../src/util');
-
-require('..');
+var sepia = require('../');
 
 // -- ECHO SERVER --------------------------------------------------------------
 

--- a/examples/substitutions.js
+++ b/examples/substitutions.js
@@ -27,7 +27,7 @@ var http = require('http');
 var request = require('request');
 var step = require('step');
 var common = require('./common');
-var sepia = require('..');
+var sepiaUtil = require('../src/util');
 
 require('..');
 
@@ -54,7 +54,7 @@ var httpServer = http.createServer(function(req, res) {
 
 // -- HTTP REQUESTS ------------------------------------------------------------
 
-function makeRequest(title, cacheHitExpected, next) {
+function makeRequest(title, next) {
   var start = Date.now();
 
   request({
@@ -72,10 +72,7 @@ function makeRequest(title, cacheHitExpected, next) {
     common.verify(function() {
       data.headers.authorization.should.equal('SERVER:TheActualSecret3');
       body.should.equal('Hello from server => TheActualSecret4');
-      //common.shouldUseCache(cacheHitExpected, time);
     });
-
-    console.log();
 
     next();
   });
@@ -92,7 +89,7 @@ step(
 
     setTimeout(this, 100);
   }, // let the server start up
-  function() { makeRequest('NO FIXTURES' , false, this); },
-  function() { makeRequest('YES FIXTURES', true , this); },
+  function() { makeRequest('NO FIXTURES' , this); },
+  function() { makeRequest('YES FIXTURES', this); },
   httpServer.close.bind(httpServer)
 );

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function shutdown(next) {
 
 var sepiaUtil = require('./src/util');
 module.exports.filter = sepiaUtil.addFilter;
+module.exports.substitute = sepiaUtil.addSubstitution;
 module.exports.fixtureDir = sepiaUtil.setFixtureDir;
 module.exports.configure = sepiaUtil.configure;
 module.exports.withSepiaServer = withSepiaServer;

--- a/src/cache.js
+++ b/src/cache.js
@@ -87,7 +87,8 @@ module.exports.configure = function(mode) {
       // exists, or we're playing back passed in data.
       function playback(resHeaders, resBody) {
         if (!forceLive) {
-          var headerContent = fs.readFileSync(filename + '.headers');
+          var headerContent = sepiaUtil.substituteWithRealValues(
+            fs.readFileSync(filename + '.headers').toString());
           resHeaders = JSON.parse(headerContent);
         }
 
@@ -119,7 +120,7 @@ module.exports.configure = function(mode) {
         }
 
         if (!forceLive) {
-          resBody = fs.readFileSync(filename);
+          resBody = sepiaUtil.substituteWithRealValues(fs.readFileSync(filename).toString());
         }
 
         req.emit('response', res);
@@ -187,7 +188,7 @@ module.exports.configure = function(mode) {
         };
 
         fs.writeFileSync(filename + '.headers',
-          JSON.stringify(headers, null, 2));
+          sepiaUtil.substituteWithOpaqueKeys(JSON.stringify(headers, null, 2)));
       }
 
       // Suppose the request times out while recording. We don't want the
@@ -228,7 +229,8 @@ module.exports.configure = function(mode) {
               headers: res.headers
             }, resBody);
           } else {
-            fs.writeFileSync(filename, resBody);
+            fs.writeFileSync(filename,
+              sepiaUtil.substituteWithOpaqueKeys(resBody.toString()));
 
             // Store the request, if debug is true
             if (debug) {

--- a/src/util.js
+++ b/src/util.js
@@ -32,6 +32,7 @@ function reset() {
     path.join(process.cwd(), 'fixtures/generated');
 
   globalOptions.filenameFilters = [];
+  globalOptions.substitutions = [];
 
   globalOptions.includeHeaderNames = true;
   globalOptions.headerWhitelist = [];
@@ -115,6 +116,33 @@ function addFilter(inFilter) {
 
   globalOptions.filenameFilters.push(filter);
 }
+
+//
+// substitutions
+//
+function addSubstitution(opaqueKey, actualValueFn) {
+  globalOptions.substitutions.push({opaqueKey: opaqueKey, actualValueFn: actualValueFn});
+}
+
+function substituteWithOpaqueKeys(text) {
+  var substitutions = globalOptions.substitutions;
+  for (var i=0; i<substitutions.length; i++) {
+    var subst = substitutions[i];
+    console.log(`substituteWithOpaqueKeys text: ${text} type=${typeof(text)}`);
+    text = text.replace(subst.actualValueFn(), subst.opaqueKey);
+  }
+  return text;
+}
+
+function substituteWithRealValues(text) {
+  var substitutions = globalOptions.substitutions;
+  for (var i=0; i<substitutions.length; i++) {
+    var subst = substitutions[i];
+    text = text.replace(subst.opaqueKey, subst.actualValueFn());
+  }
+  return text;
+}
+
 
 // -- UTILITY FUNCTIONS --------------------------------------------------------
 
@@ -438,6 +466,9 @@ module.exports.shouldForceLive = shouldForceLive;
 module.exports.removeInternalHeaders = removeInternalHeaders;
 module.exports.findTheBestMatchingFixture = findTheBestMatchingFixture;
 module.exports.shouldFindMatchingFixtures = shouldFindMatchingFixtures;
+module.exports.addSubstitution = addSubstitution;
+module.exports.substituteWithRealValues = substituteWithRealValues;
+module.exports.substituteWithOpaqueKeys = substituteWithOpaqueKeys;
 
 module.exports.internal = {};
 module.exports.internal.globalOptions = globalOptions;

--- a/src/util.js
+++ b/src/util.js
@@ -128,7 +128,6 @@ function substituteWithOpaqueKeys(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    console.log(`substituteWithOpaqueKeys text: ${text} type=${typeof(text)}`);
     text = text.replace(subst.actualValueFn(), subst.opaqueKey);
   }
   return text;
@@ -372,7 +371,6 @@ function constructFilename(method, reqUrl, reqBody, reqHeaders) {
 
   logFixtureStatus(hashFile, hashParts);
   touchOnHit(hashFile);
-
   return hashFile;
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -128,7 +128,7 @@ function substituteWithOpaqueKeys(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(subst.actualValueFn(), subst.opaqueKey);
+    text = text.split(subst.actualValueFn()).join(subst.opaqueKey);
   }
   return text;
 }
@@ -137,7 +137,7 @@ function substituteWithRealValues(text) {
   var substitutions = globalOptions.substitutions;
   for (var i=0; i<substitutions.length; i++) {
     var subst = substitutions[i];
-    text = text.replace(subst.opaqueKey, subst.actualValueFn());
+    text = text.split(subst.opaqueKey).join(subst.actualValueFn());
   }
   return text;
 }

--- a/test/util.js
+++ b/test/util.js
@@ -52,8 +52,8 @@ describe('utils.js', function() {
       addSubstitution('<OPAQUE1>', valfn1);
       addSubstitution('<OPAQUE2>', valfn2);
 
-      var text = substituteWithOpaqueKeys('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
-      text.should.equal('A:<OPAQUE1>:B:<OPAQUE2>:C:<OPAQUE1>:D:<OPAQUE2>');
+      var text = substituteWithOpaqueKeys('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2:E:realvalue1:F:realvalue2');
+      text.should.equal('A:<OPAQUE1>:B:<OPAQUE2>:C:<OPAQUE1>:D:<OPAQUE2>:E:<OPAQUE1>:F:<OPAQUE2>');
     });
   });
 
@@ -61,14 +61,14 @@ describe('utils.js', function() {
     const substituteWithRealValues= sepiaUtil.substituteWithRealValues;
     const addSubstitution = sepiaUtil.addSubstitution;
 
-    it('should substitute opaque keys with opaque keys', function () {
+    it('should substitute opaque keys with real values', function () {
       var valfn1 = function() {return 'realvalue1'; };
       var valfn2 = function() {return 'realvalue2'; };
       addSubstitution('<OPAQUE1>', valfn1);
       addSubstitution('<OPAQUE2>', valfn2);
 
-      var text = substituteWithRealValues('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
-      text.should.equal('A:realvalue1:B:realvalue2:C:realvalue1:D:realvalue2');
+      var text = substituteWithRealValues('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2:E:<OPAQUE1>:F:<OPAQUE2>');
+      text.should.equal('A:realvalue1:B:realvalue2:C:realvalue1:D:realvalue2:E:realvalue1:F:realvalue2');
     });
   });
 

--- a/test/util.js
+++ b/test/util.js
@@ -25,6 +25,53 @@ describe('utils.js', function() {
     sepiaUtil.reset();
   });
 
+  describe('#addSubstitution', function() {
+    const addSubstitution = sepiaUtil.addSubstitution;
+
+    it('should store a list of substitutions', function() {
+      var valfn1 = function() { return 'realvalue1'; };
+      var valfn2 = function() {return 'realvalue2'; };
+      addSubstitution('<OPAQUE1>', valfn1);
+      addSubstitution('<OPAQUE2>', valfn2);
+
+      var substitutions = sepiaUtil.internal.globalOptions.substitutions;
+      substitutions[0].opaqueKey.should.equal('<OPAQUE1>');
+      substitutions[0].actualValueFn().should.equal('realvalue1');
+      substitutions[1].opaqueKey.should.equal('<OPAQUE2>');
+      substitutions[1].actualValueFn().should.equal('realvalue2');
+    });
+  });
+
+  describe('#substituteWithOpaqueKeys', function() {
+    const substituteWithOpaqueKeys = sepiaUtil.substituteWithOpaqueKeys;
+    const addSubstitution = sepiaUtil.addSubstitution;
+
+    it('should substitute real values with opaque keys', function () {
+      var valfn1 = function() {return 'realvalue1'; };
+      var valfn2 = function() {return 'realvalue2'; };
+      addSubstitution('<OPAQUE1>', valfn1);
+      addSubstitution('<OPAQUE2>', valfn2);
+
+      var text = substituteWithOpaqueKeys('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
+      text.should.equal('A:<OPAQUE1>:B:<OPAQUE2>:C:<OPAQUE1>:D:<OPAQUE2>');
+    });
+  });
+
+  describe('#substituteWithRealValues', function() {
+    const substituteWithRealValues= sepiaUtil.substituteWithRealValues;
+    const addSubstitution = sepiaUtil.addSubstitution;
+
+    it('should substitute opaque keys with opaque keys', function () {
+      var valfn1 = function() {return 'realvalue1'; };
+      var valfn2 = function() {return 'realvalue2'; };
+      addSubstitution('<OPAQUE1>', valfn1);
+      addSubstitution('<OPAQUE2>', valfn2);
+
+      var text = substituteWithRealValues('A:<OPAQUE1>:B:<OPAQUE2>:C:realvalue1:D:realvalue2');
+      text.should.equal('A:realvalue1:B:realvalue2:C:realvalue1:D:realvalue2');
+    });
+  });
+
   describe('#addFilter', function() {
     const addFilter = sepiaUtil.addFilter;
 
@@ -961,4 +1008,3 @@ describe('utils.js', function() {
 
   });
 });
-


### PR DESCRIPTION
Note: This replaces the previous PR #20 (which was from my master branch).

Adds substitution capability suggested in #13.  

Now you can do:

```javascript
var sepia = require('sepia');

sepia.substitute('<MYSECRET>', function () { return process.env.MY_ACCESS_TOKEN; });
sepia.substitute('<MYSECRET2>', function () { return process.env.MY_ACCESS_TOKEN2; });
// etc.
```

And the fixtures will contain `<MYSECRET>` and `<MYSECRET2>`, while the requests will contain the value of MY_ACCESS_TOKEN and MY_ACCESS_TOKEN2.

I added tests, but couldn't quite figure out how to test the fixture files themselves.  I did check that they look right, though.

@avik-das - Could you take a look?