### PR TITLE
Add includeHeaderValues option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ and while one may wish to exercise both mechanisms, it is not useful to require
 that the actual authentication cookie have a particular value.
 
 Sepia generates filenames based on the presence and absence of header and
-cookie _names_. In particular, all the header names are lower-cased and sorted
-alphabetically, and this list is used to construct the fixture filename
+cookie _names_ by default. In particular, all the header names are lower-cased
+and sorted alphabetically, and this list is used to construct the fixture filename
 corresponding to a request. The same applies to the cookie names.
+
 
 If this feature is not desired, it can be disabled by calling
 `sepia.configure()`:
@@ -231,6 +232,15 @@ If this feature is not desired, it can be disabled by calling
     sepia.configure({
       includeHeaderNames: false,
       includeCookieNames: false
+    });
+
+
+If you also want to include header values, set the includeHeaderValues flag in the
+configure options:
+
+    var sepia = require('sepia');
+    sepia.configure({
+      includeHeaderValues: true
     });
 
 Additionally, a whitelist can be specified for the headers or for the cookies.
@@ -399,4 +409,3 @@ data is retrieved from a file and sent back using a dummy response object.
 * [Deepank Gupta](https://github.com/deepankgupta)
 * [Priyanka Salvi](https://github.com/salvipriyanka/)
 * [Ashima Atul](https://github.com/ashimaatul)
-

--- a/src/util.js
+++ b/src/util.js
@@ -340,7 +340,6 @@ function constructAndCreateFixtureFolder(reqUrl, reqHeaders) {
 
 function constructFilename(method, reqUrl, reqBody, reqHeaders) {
   var hashParts = gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders);
-  console.log('HashParts',hashParts);
   var hash = crypto.createHash('md5');
   hash.update(JSON.stringify(hashParts));
 

--- a/src/util.js
+++ b/src/util.js
@@ -61,6 +61,10 @@ function configure(options) {
     globalOptions.includeHeaderNames = options.includeHeaderNames;
   }
 
+  if (options.includeHeaderValues) {
+    globalOptions.includeHeaderValues = options.includeHeaderValues;
+  }
+
   if (options.headerWhitelist != null) {
     globalOptions.headerWhitelist = options.headerWhitelist.map(
       function(item) {
@@ -268,18 +272,19 @@ function parseCookiesNames(cookieValue) {
   return cookies.sort();
 }
 
-function parseHeaders(headers, includeHeaderValues) {
+function parseHeaders(headers) {
   headers = removeInternalHeaders(headers);
   var headerData = [];
   var whitelist = globalOptions.headerWhitelist || [];
 
   for (var name in headers) {
-    if (headers.hasOwnProperty(name) && (whitelist.length===0 || whitelist.indexOf(name)>=0)) {
-      if (includeHeaderValues) {
-        headerData.push(name.toLowerCase() + ':' + headers[name]);
+    var lowerName = name.toLowerCase();
+    if (headers.hasOwnProperty(name) && (whitelist.length===0 || whitelist.indexOf(lowerName)>=0)) {
+      if (globalOptions.includeHeaderValues) {
+        headerData.push(lowerName + ':' + headers[name]);
       }
       else {
-        headerData.push(name.toLowerCase());
+        headerData.push(lowerName);
       }
     }
   }
@@ -295,7 +300,7 @@ function gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders) {
 
   var headers = [];
   if (globalOptions.includeHeaderNames || globalOptions.includeHeaderValues) {
-    headers = parseHeaders(reqHeaders, globalOptions.includeHeaderValues);
+    headers = parseHeaders(reqHeaders);
   }
 
   var cookieNames = [];

--- a/src/util.js
+++ b/src/util.js
@@ -33,6 +33,7 @@ function reset() {
 
   globalOptions.filenameFilters = [];
 
+  globalOptions.includeHeaderValues = false;
   globalOptions.includeHeaderNames = true;
   globalOptions.headerWhitelist = [];
 
@@ -267,18 +268,23 @@ function parseCookiesNames(cookieValue) {
   return cookies.sort();
 }
 
-function parseHeaderNames(headers) {
+function parseHeaders(headers, includeHeaderValues) {
   headers = removeInternalHeaders(headers);
+  var headerData = [];
+  var whitelist = globalOptions.headerWhitelist || [];
 
-  var headerNames = [];
   for (var name in headers) {
-    if (headers.hasOwnProperty(name)) {
-      headerNames.push(name.toLowerCase());
+    if (headers.hasOwnProperty(name) && (whitelist.length===0 || whitelist.indexOf(name)>=0)) {
+      if (includeHeaderValues) {
+        headerData.push(name.toLowerCase() + ':' + headers[name]);
+      }
+      else {
+        headerData.push(name.toLowerCase());
+      }
     }
   }
 
-  headerNames = filterByWhitelist(headerNames, globalOptions.headerWhitelist);
-  return headerNames.sort();
+  return headerData.sort();
 }
 
 function gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders) {
@@ -287,9 +293,9 @@ function gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders) {
 
   var filtered = applyMatchingFilters(reqUrl, reqBody);
 
-  var headerNames = [];
-  if (globalOptions.includeHeaderNames) {
-    headerNames = parseHeaderNames(reqHeaders);
+  var headers = [];
+  if (globalOptions.includeHeaderNames || globalOptions.includeHeaderValues) {
+    headers = parseHeaders(reqHeaders, globalOptions.includeHeaderValues);
   }
 
   var cookieNames = [];
@@ -305,7 +311,7 @@ function gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders) {
     ['method', method],
     ['url', filtered.filteredUrl],
     ['body', filtered.filteredBody],
-    ['headerNames', headerNames],
+    ['headerNames', headers],
     ['cookieNames', cookieNames]
   ];
 }
@@ -334,7 +340,7 @@ function constructAndCreateFixtureFolder(reqUrl, reqHeaders) {
 
 function constructFilename(method, reqUrl, reqBody, reqHeaders) {
   var hashParts = gatherFilenameHashParts(method, reqUrl, reqBody, reqHeaders);
-
+  console.log('HashParts',hashParts);
   var hash = crypto.createHash('md5');
   hash.update(JSON.stringify(hashParts));
 
@@ -449,7 +455,7 @@ module.exports.internal.log = log;
 module.exports.internal.logFixtureStatus = logFixtureStatus;
 module.exports.internal.logFixtureDebugStatus = logFixtureDebugStatus;
 module.exports.internal.parseCookiesNames = parseCookiesNames;
-module.exports.internal.parseHeaderNames = parseHeaderNames;
+module.exports.internal.parseHeaders = parseHeaders;
 module.exports.internal.applyMatchingFilters = applyMatchingFilters;
 module.exports.internal.gatherFilenameHashParts = gatherFilenameHashParts;
 module.exports.internal.constructAndCreateFixtureFolder =

--- a/test/util.js
+++ b/test/util.js
@@ -505,6 +505,31 @@ describe('utils.js', function() {
       }).should.eql(['a', 'b']);
     });
 
+    it('includes header values if requested', function () {
+      sepiaUtil.configure({
+        includeHeaderValues: true
+      });
+
+      parseHeaders({
+        b: 1,
+        c: 2,
+        a: 3
+      }).should.eql(['a:3', 'b:1', 'c:2']);
+    });
+
+    it('includes header values if requested and filters by whitelist case insensitively', function () {
+      sepiaUtil.configure({
+        includeHeaderValues: true,
+        headerWhitelist: ['A', 'B']
+      });
+
+      parseHeaders({
+        b: 1,
+        c: 2,
+        a: 3
+      }).should.eql(['a:3', 'b:1']);
+    });
+
     it('filters out sepia headers', function() {
       parseHeaders({
         b: 1,

--- a/test/util.js
+++ b/test/util.js
@@ -459,16 +459,16 @@ describe('utils.js', function() {
     });
   });
 
-  describe('#parseHeaderNames', function() {
-    const parseHeaderNames = sepiaUtil.internal.parseHeaderNames;
+  describe('#parseHeaders', function() {
+    const parseHeaders = sepiaUtil.internal.parseHeaders;
 
     it('returns an empty list when there are no headers', function() {
-      parseHeaderNames().should.eql([]);
-      parseHeaderNames({}).should.eql([]);
+      parseHeaders().should.eql([]);
+      parseHeaders({}).should.eql([]);
     });
 
     it('parses out all header names when there is no whitelist', function() {
-      parseHeaderNames({
+      parseHeaders({
         name1: 'value1',
         name2: 'value2'
       }).should.eql([
@@ -478,7 +478,7 @@ describe('utils.js', function() {
     });
 
     it('alphabetizes the header names', function() {
-      parseHeaderNames({
+      parseHeaders({
         b: 1,
         c: 2,
         a: 3
@@ -486,7 +486,7 @@ describe('utils.js', function() {
     });
 
     it('lower cases the header names', function() {
-      parseHeaderNames({
+      parseHeaders({
         A: 1,
         B: 2,
         C: 3
@@ -498,7 +498,7 @@ describe('utils.js', function() {
         headerWhitelist: ['a', 'b']
       });
 
-      parseHeaderNames({
+      parseHeaders({
         b: 1,
         c: 2,
         a: 3
@@ -506,7 +506,7 @@ describe('utils.js', function() {
     });
 
     it('filters out sepia headers', function() {
-      parseHeaderNames({
+      parseHeaders({
         b: 1,
         'x-sepia-internal-header': 2,
         a: 3
@@ -754,9 +754,9 @@ describe('utils.js', function() {
     });
 
 
-    it('constructs using all the available information', function() {
+    it('constructs using all the available information using default values', function() {
       sepiaUtil.setFixtureDir('/global/fixture/dir');
-      sepiaUtil.setTestOptions({ testName: 'test/name' });
+      sepiaUtil.setTestOptions({ testName: 'test/name', });
 
       var filename = constructFilename('get', 'my-url', 'my-body', {
         'accept-language': 'en-US',
@@ -767,6 +767,7 @@ describe('utils.js', function() {
       filename.should.equal('/global/fixture/dir/en-US/test/name/' +
         '32772f774a3f187d465d47a526b80e6f');
     });
+
   });
 
   describe('#urlFromHttpRequestOptions', function() {
@@ -961,4 +962,3 @@ describe('utils.js', function() {
 
   });
 });
-


### PR DESCRIPTION
This PR provides the ability to include header values when generating the filename hash. This addresses #21.

Now you can do:
```javascript
var sinon = require('sinon');
sinon.configure({ includeHeaderValues: true });
```

The generated hash will be sensitive to header values, and if a headerWhitelist is set only values from those headers will be used.  Note that it is redundant to set includeHeaderNames when includeHeaderValues is set.

* updated the README
* added tests

Note: To preserve backwards compatibility with existing filenames, I preserved “headerNames”
in the hashparts array instead of renaming it to “headers” as would otherwise make sense.