### PR TITLE
Do not proxy live requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,5 +60,6 @@ var sepiaUtil = require('./src/util');
 module.exports.filter = sepiaUtil.addFilter;
 module.exports.fixtureDir = sepiaUtil.setFixtureDir;
 module.exports.configure = sepiaUtil.configure;
+module.exports.disableGzip = sepiaUtil.disableGzip;
 module.exports.withSepiaServer = withSepiaServer;
 module.exports.shutdown = shutdown;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sepia",
   "author": "Avik Das <avik.das@berkeley.edu>",
-  "version": "2.0.1",
+  "version": "2.0.4",
   "description": "A VCR-like module that records HTTP interactions and plays them back for speed and reliability",
   "keywords": [
     "http",

--- a/src/cache.js
+++ b/src/cache.js
@@ -187,10 +187,12 @@ module.exports.configure = function(mode) {
         var timeLength = Date.now() - startTime;
         headers.url = reqUrl;
         headers.time = timeLength;
-        headers.request = {
-          method: options.method,
-          headers: options.headers
-        };
+        // Do not include the request in the header file
+        // it's not used and there is a separate debug option for this
+        // headers.request = {
+        //   method: options.method,
+        //   headers: sepiaUtil.parseHeaderNames(options.headers)
+        // };
 
         fs.writeFileSync(filename + '.headers',
           JSON.stringify(headers, null, 2));

--- a/src/cache.js
+++ b/src/cache.js
@@ -52,6 +52,14 @@ module.exports.configure = function(mode) {
 
   protocolModule.request = function(options, callback) {
     var reqUrl = sepiaUtil.urlFromHttpRequestOptions(options, protocol);
+    var forceLive = sepiaUtil.shouldForceLive(reqUrl);
+
+    if (forceLive) {
+      // Just pass thru live requests
+      // websocket connections fail if we proxy
+      return oldRequest.apply(this, arguments);
+    }
+
     var reqBody = [];
     var debug = sepiaUtil.shouldFindMatchingFixtures();
 
@@ -80,8 +88,6 @@ module.exports.configure = function(mode) {
         reqBody.toString(), options.headers);
 
       options.headers = sepiaUtil.removeInternalHeaders(options.headers);
-
-      var forceLive = sepiaUtil.shouldForceLive(reqUrl);
 
       // Only called if either the fixture with the constructed filename
       // exists, or we're playing back passed in data.

--- a/src/cache.js
+++ b/src/cache.js
@@ -60,6 +60,15 @@ module.exports.configure = function(mode) {
       return oldRequest.apply(this, arguments);
     }
 
+    // Remove any gzip headers
+    if (sepiaUtil.gzipDisabled()) {
+      if (options.headers && options.headers['accept-encoding']) {
+        var gzipHeaders = ['gzip,deflate'];
+        options.headers['accept-encoding'] = options.headers['accept-encoding']
+          .filter((h) => !gzipHeaders.includes(h));
+      }
+    }
+
     var reqBody = [];
     var debug = sepiaUtil.shouldFindMatchingFixtures();
 

--- a/src/util.js
+++ b/src/util.js
@@ -50,6 +50,9 @@ function reset() {
   // These test options are set via an HTTP request to the embedded HTTP server
   // provided by sepia. The options are reset each time any of them are set.
   globalOptions.testOptions = {};
+
+  // Strip out gzip headers so plain text is provided
+  globalOptions.doNotGzip = false;
 }
 
 // automatically reset the state of the module when 'required'.
@@ -91,12 +94,24 @@ function configure(options) {
   if (options.debug != null) {
     globalOptions.debug = options.debug;
   }
+
+  if (options.doNotGzip != null) {
+    globalOptions.doNotGzip = options.doNotGzip;
+  }
 }
 
 // This is a commonly-used option, and thus, it should have its own function to
 // set its value.
 function setFixtureDir(fixtureDir) {
   globalOptions.filenamePrefix = fixtureDir;
+}
+
+function disableGzip() {
+  globalOptions.doNotGzip = true;
+}
+
+function gzipDisabled() {
+  return globalOptions.doNotGzip;
 }
 
 function setTestOptions(options) {
@@ -431,6 +446,8 @@ module.exports.reset = reset;
 module.exports.configure = configure;
 module.exports.setFixtureDir = setFixtureDir;
 module.exports.setTestOptions = setTestOptions;
+module.exports.disableGzip = disableGzip;
+module.exports.gzipDisabled = gzipDisabled;
 module.exports.addFilter = addFilter;
 module.exports.constructFilename = constructFilename;
 module.exports.urlFromHttpRequestOptions = urlFromHttpRequestOptions;


### PR DESCRIPTION
This fixes a bug where websocket requests will always stall.

This just passes through live requests to the original protocol instead of proxying.